### PR TITLE
Add operational guidance

### DIFF
--- a/CUSTOM_AUTH_PLAN.md
+++ b/CUSTOM_AUTH_PLAN.md
@@ -97,9 +97,19 @@
 - ブルートフォース検出 (fail‑2‑ban 相当)  
 - `JWT_SIGNING_KEY` を 90 日ごとにローテーションし 2 キー重複期間を設ける  
 - API 側のパスワードハッシュは **argon2id**  
-- CSP で `eval` やインラインスクリプトを禁止  
+- CSP で `eval` やインラインスクリプトを禁止
 
 - SSG/ISR ページにユーザー固有データを埋め込む場合は GSSP に切り替える指針を明記
+
+### シークレット管理
+- `JWT_SIGNING_KEY` は Secret Manager など外部シークレットストアに保存し、デプロイ時に環境変数として注入する
+
+### 監査ログ
+- `timestamp`, `requestId`, `userId`, `action` を含む JSON Lines 形式で出力し、長期保管する
+
+### Prometheus 指標例
+- `bff_request_total{route="/api/auth/login"}` などのリクエストカウント
+- `bff_request_duration_seconds` ヒストグラムでレイテンシを計測
 
 ---
 


### PR DESCRIPTION
## Summary
- add secret management, audit log and Prometheus metrics guidance

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6870c9a36cc4832097ac2ba54a76f404